### PR TITLE
Journey에 Security 적용, 페이징 에러 해결

### DIFF
--- a/server/src/main/java/onde/there/journey/controller/JourneyController.java
+++ b/server/src/main/java/onde/there/journey/controller/JourneyController.java
@@ -15,6 +15,7 @@ import onde.there.dto.journy.JourneyDto.FilteringResponse;
 import onde.there.dto.journy.JourneyDto.JourneyListResponse;
 import onde.there.dto.journy.JourneyDto.MyListResponse;
 import onde.there.journey.service.JourneyService;
+import onde.there.member.security.jwt.TokenMemberId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
@@ -47,10 +48,11 @@ public class JourneyController {
 			content = @Content(schema = @Schema(implementation = JourneyDto.CreateRequest.class)))
 		@RequestPart @Valid JourneyDto.CreateRequest request,
 		@Parameter(description = "Thumbnail 이미지 파일", required = true)
-		@RequestPart MultipartFile thumbnail) {
+		@RequestPart MultipartFile thumbnail,
+		@TokenMemberId String memberId) {
 
 		return ResponseEntity.ok(
-			journeyService.createJourney(request, thumbnail));
+			journeyService.createJourney(request, thumbnail, memberId));
 	}
 
 	@Operation(summary = "여정 수정", description = "여정을 수정합니다.")
@@ -63,10 +65,11 @@ public class JourneyController {
 			content = @Content(schema = @Schema(implementation = JourneyDto.UpdateRequest.class)))
 		@RequestPart @Valid JourneyDto.UpdateRequest request,
 		@Parameter(description = "Thumbnail 이미지 파일", required = true)
-		@RequestPart MultipartFile thumbnail) {
+		@RequestPart MultipartFile thumbnail,
+		@TokenMemberId String memberId) {
 
 		return ResponseEntity.ok(
-			journeyService.updateJourney(request, thumbnail));
+			journeyService.updateJourney(request, thumbnail, memberId));
 	}
 
 	@Operation(summary = "여정 삭제", description = "여정을 삭제합니다.")
@@ -74,9 +77,10 @@ public class JourneyController {
 	@DeleteMapping
 	public ResponseEntity<String> deleteJourney(
 		@Parameter(description = "삭제할 여정 id", required = true)
-		@RequestParam Long journeyId) {
+		@RequestParam Long journeyId,
+		@TokenMemberId String memberId) {
 
-		journeyService.deleteJourney(journeyId);
+		journeyService.deleteJourney(journeyId, memberId);
 
 		return ResponseEntity.ok("journeyId : " + journeyId);
 	}
@@ -108,7 +112,7 @@ public class JourneyController {
 	@GetMapping("/my-list")
 	public ResponseEntity<Page<MyListResponse>> getMyJourneyList(
 		@Parameter(description = "내 아이디", required = true)
-		@RequestParam String memberId, Pageable pageable) {
+		@TokenMemberId String memberId, Pageable pageable) {
 
 		return ResponseEntity.ok(journeyService.myList(memberId, pageable));
 	}

--- a/server/src/main/java/onde/there/journey/repository/JourneyRepositoryImpl.java
+++ b/server/src/main/java/onde/there/journey/repository/JourneyRepositoryImpl.java
@@ -54,9 +54,7 @@ public class JourneyRepositoryImpl implements JourneyRepositoryCustom {
 				journey.disclosure.eq("public"),
 				filteredRegion,
 				filteredTheme,
-				eqTitle(filteringRequest.getKeyword())
-			)
-			.groupBy(journey);
+				eqTitle(filteringRequest.getKeyword()));
 
 		return PageableExecutionUtils.getPage(content, pageable,
 			countQuery::fetchOne);
@@ -78,8 +76,7 @@ public class JourneyRepositoryImpl implements JourneyRepositoryCustom {
 			.select(journey.count())
 			.from(journey)
 			.innerJoin(journey.journeyThemes, journeyTheme)
-			.where(eqMemberId(memberId))
-			.groupBy(journey);
+			.where(eqMemberId(memberId));
 
 		return PageableExecutionUtils.getPage(content, pageable,
 			countQuery::fetchOne);

--- a/server/src/main/java/onde/there/journey/service/JourneyService.java
+++ b/server/src/main/java/onde/there/journey/service/JourneyService.java
@@ -28,7 +28,6 @@ import onde.there.dto.journy.JourneyDto.UpdateResponse;
 import onde.there.image.service.AwsS3Service;
 import onde.there.journey.exception.JourneyException;
 import onde.there.journey.repository.JourneyRepository;
-import onde.there.journey.repository.JourneyRepositoryImpl;
 import onde.there.journey.repository.JourneyThemeRepository;
 import onde.there.member.repository.MemberRepository;
 import onde.there.place.exception.PlaceErrorCode;
@@ -54,13 +53,11 @@ public class JourneyService {
 
 	@Transactional
 	public JourneyDto.CreateResponse createJourney(
-		JourneyDto.CreateRequest request, MultipartFile thumbnail, String memberId) {
+		JourneyDto.CreateRequest request, MultipartFile thumbnail,
+		String memberId) {
 
 		log.info("createJourney() : 호출");
 
-		Member member = new Member("test", "test", "test", "test",
-			"testNickname");
-		memberRepository.save(member);
 		Member checkMember = memberRepository.findById(memberId)
 			.orElseThrow(() -> new JourneyException(NOT_FOUND_MEMBER));
 
@@ -75,7 +72,7 @@ public class JourneyService {
 			+ "(여정 thumbnail URL : " + imageUrls.get(0) + ")");
 
 		Journey journey = Journey.builder()
-			.member(member)
+			.member(checkMember)
 			.title(request.getTitle())
 			.startDate(request.getStartDate())
 			.endDate(request.getEndDate())

--- a/server/src/main/java/onde/there/journey/service/JourneyService.java
+++ b/server/src/main/java/onde/there/journey/service/JourneyService.java
@@ -49,20 +49,19 @@ public class JourneyService {
 	private final JourneyRepository journeyRepository;
 	private final JourneyThemeRepository journeyThemeRepository;
 	private final MemberRepository memberRepository;
-	private final JourneyRepositoryImpl journeyRepositoryImpl;
 	private final AwsS3Service awsS3Service;
 	private final PlaceRepository placeRepository;
 
 	@Transactional
 	public JourneyDto.CreateResponse createJourney(
-		JourneyDto.CreateRequest request, MultipartFile thumbnail) {
+		JourneyDto.CreateRequest request, MultipartFile thumbnail, String memberId) {
 
 		log.info("createJourney() : 호출");
 
 		Member member = new Member("test", "test", "test", "test",
 			"testNickname");
 		memberRepository.save(member);
-		Member checkMember = memberRepository.findById(request.getMemberId())
+		Member checkMember = memberRepository.findById(memberId)
 			.orElseThrow(() -> new JourneyException(NOT_FOUND_MEMBER));
 
 		if (request.getEndDate().isBefore(request.getStartDate())) {
@@ -131,7 +130,7 @@ public class JourneyService {
 			.orElseThrow(() -> new JourneyException(NOT_FOUND_MEMBER));
 
 		PageImpl<MyListResponse> MyListResponses = new PageImpl<>(
-			journeyRepositoryImpl.myList(memberId, pageable).stream()
+			journeyRepository.myList(memberId, pageable).stream()
 				.map(MyListResponse::fromEntity).collect(
 					Collectors.toList()));
 
@@ -147,7 +146,7 @@ public class JourneyService {
 		log.info("filteredList() : 호출");
 
 		PageImpl<FilteringResponse> filteringResponses = new PageImpl<>(
-			journeyRepositoryImpl.searchAll(filteringRequest, pageable).stream()
+			journeyRepository.searchAll(filteringRequest, pageable).stream()
 				.map(FilteringResponse::fromEntity).collect(
 					Collectors.toList()));
 
@@ -202,12 +201,17 @@ public class JourneyService {
 	}
 
 	@Transactional
-	public void deleteJourney(Long journeyId) {
+	public void deleteJourney(Long journeyId, String memberId) {
 
 		log.info("deleteJourney() : 호출");
 
 		Journey journey = journeyRepository.findById(journeyId)
 			.orElseThrow(() -> new JourneyException(NOT_FOUND_JOURNEY));
+
+		String Author = journey.getMember().getId();
+		if (!Objects.equals(Author, memberId)) {
+			throw new JourneyException(YOU_ARE_NOT_THE_AUTHOR);
+		}
 
 		List<JourneyTheme> journeyThemeTypeList = journeyThemeRepository
 			.findAllByJourneyId(journey.getId());
@@ -231,15 +235,15 @@ public class JourneyService {
 
 	@Transactional
 	public UpdateResponse updateJourney(UpdateRequest request,
-		MultipartFile thumbnail) {
+		MultipartFile thumbnail, String memberId) {
 
 		log.info("updateJourney() : 호출");
 
 		Journey journey = journeyRepository.findById(request.getJourneyId())
 			.orElseThrow(() -> new JourneyException(NOT_FOUND_JOURNEY));
 
-		String email = journey.getMember().getEmail();
-		if (!Objects.equals(email, request.getMemberId())) {
+		String Author = journey.getMember().getId();
+		if (!Objects.equals(Author, memberId)) {
 			throw new JourneyException(YOU_ARE_NOT_THE_AUTHOR);
 		}
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -2,46 +2,9 @@ spring:
   config:
     import:
       - classpath:awsS3.yml
+      - classpath:db-connection.yml
+      - classpath:mail.yml
       - classpath:oauth2.yml
-  redis:
-    host: localhost
-    port: 6379
-  datasource:
-    hikari:
-      maximum-pool-size: 20
-    url: jdbc:h2:mem:test
-    username: sa
-    password:
-    driverClassName: org.h2.Driver
-#    url: jdbc:mysql://localhost:3306/there?serverTimezone=Asia/Seoul
-#    username:
-#    password:
-#    driverClassName: com.mysql.cj.jdbc.Driver
-
-  h2:
-    console:
-      enabled: true
-  jpa:
-    defer-datasource-initialization: true
-    database-platform: H2
-    hibernate:
-      ddl-auto: create-drop
-    open-in-view: false
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username:
-    password:
-    properties:
-      mail:
-        smtp:
-          starttls:
-            enable: true
-          auth: true
 
 springdoc:
   swagger-ui:

--- a/server/src/test/java/onde/there/journey/service/JourneyServiceTest.java
+++ b/server/src/test/java/onde/there/journey/service/JourneyServiceTest.java
@@ -1,386 +1,418 @@
-package onde.there.journey.service;
-
-import static onde.there.journey.exception.JourneyErrorCode.THERE_IS_NO_MATCHING_THEME;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import onde.there.domain.Journey;
-import onde.there.domain.JourneyTheme;
-import onde.there.domain.Member;
-import onde.there.domain.type.JourneyThemeType;
-import onde.there.domain.type.RegionType;
-import onde.there.dto.journy.JourneyDto;
-import onde.there.dto.journy.JourneyDto.CreateRequest;
-import onde.there.dto.journy.JourneyDto.CreateResponse;
-import onde.there.dto.journy.JourneyDto.JourneyListResponse;
-import onde.there.image.service.AwsS3Service;
-import onde.there.journey.exception.JourneyErrorCode;
-import onde.there.journey.exception.JourneyException;
-import onde.there.journey.repository.JourneyRepository;
-import onde.there.journey.repository.JourneyThemeRepository;
-import onde.there.member.repository.MemberRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-
-@ExtendWith(MockitoExtension.class)
-public class JourneyServiceTest {
-
-	@Mock
-	private MemberRepository memberRepository;
-
-	@Mock
-	private JourneyRepository journeyRepository;
-
-	@Mock
-	private JourneyThemeRepository journeyThemeRepository;
-
-	@InjectMocks
-	private JourneyService journeyService;
-
-	@Mock
-	private AwsS3Service awsS3Service;
-
-	@Test
-	void createJourneySuccess() throws IOException {
-
-		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-			"온데");
-
-		given(memberRepository.findById(anyString()))
-			.willReturn(Optional.of(member));
-
-		String fileName = "1";
-		String contentType = "png";
-		String filePath = "src/main/resources/testImages/1.png";
-		FileInputStream fileInputStream = new FileInputStream(
-			new File(filePath));
-		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
-			fileName + "." + contentType, contentType, fileInputStream);
-
-		given(awsS3Service.uploadFiles(any()))
-			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
-
-		ArgumentCaptor<Journey> journeyCaptor = ArgumentCaptor.forClass(
-			Journey.class);
-		ArgumentCaptor<JourneyTheme> journeyThemeCaptor = ArgumentCaptor.forClass(
-			JourneyTheme.class);
-
-		CreateResponse journeyDto = journeyService.createJourney(
-			CreateRequest.builder()
-				.memberId("tHereId")
-				.title("TitleTest")
-				.startDate(LocalDate.parse("2022-10-16"))
-				.endDate(LocalDate.parse("2022-10-17"))
-				.disclosure("public")
-				.journeyThemes(Arrays.asList("힐링", "식도락"))
-				.introductionText("테스트 소개 글")
-				.numberOfPeople(7)
-				.region("서울")
-				.build(),
-			mockMultipartFile
-		);
-
-		verify(journeyRepository, times(1))
-			.save(journeyCaptor.capture());
-		verify(journeyThemeRepository, times(2))
-			.save(journeyThemeCaptor.capture());
-
-		assertEquals("tHereId", journeyDto.getMemberId());
-		assertEquals("TitleTest", journeyDto.getTitle());
-		assertEquals(LocalDate.parse("2022-10-16"),
-			journeyDto.getStartDate());
-		assertEquals(LocalDate.parse("2022-10-17"),
-			journeyDto.getEndDate());
-		assertNotNull(journeyDto.getJourneyThumbnailUrl());
-		assertEquals(JourneyThemeType.HEALING,
-			journeyThemeCaptor.getAllValues().get(0).getJourneyThemeName());
-		assertEquals(JourneyThemeType.RESTAURANT,
-			journeyThemeCaptor.getAllValues().get(1).getJourneyThemeName());
-		assertEquals("서울", journeyDto.getRegion());
-
-	}
-
-	@Test
-	@DisplayName("종료 날짜가 시작 날짜보다 과거 - 여정 생성 실패")
-	void createJourney_DateError() throws IOException {
-
-		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-			"온데");
-
-		given(memberRepository.findById(anyString()))
-			.willReturn(Optional.of(member));
-
-		FileInputStream fis = new FileInputStream(
-			"src/main/resources/testImages/" + "1.png");
-		MockMultipartFile testThumbnail = new MockMultipartFile("1", "1.png",
-			"png", fis);
-
-		JourneyException exception = assertThrows(JourneyException.class,
-			() -> journeyService.createJourney(
-				CreateRequest.builder()
-					.memberId("tHereEmail")
-					.title("TitleTest")
-					.startDate(LocalDate.parse("2022-10-16"))
-					.endDate(LocalDate.parse("2022-10-15"))
-					.disclosure("public")
-					.journeyThemes(Arrays.asList("힐링", "식도락"))
-					.introductionText("테스트 소개 글")
-					.numberOfPeople(7)
-					.region("서울")
-					.build(),
-				testThumbnail));
-
-		assertEquals(JourneyErrorCode.DATE_ERROR, exception.getErrorCode());
-	}
-
-	@Test
-	@DisplayName("일치하는 테마가 없을 때 - 여정 생성 실패")
-	void createJourney_THERE_IS_NO_MATCHING_THEME() throws IOException {
-
-		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-			"온데");
-
-		given(memberRepository.findById(anyString()))
-			.willReturn(Optional.of(member));
-
-		String fileName = "1";
-		String contentType = "png";
-		String filePath = "src/main/resources/testImages/1.png";
-		FileInputStream fileInputStream = new FileInputStream(
-			new File(filePath));
-		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
-			fileName + "." + contentType, contentType, fileInputStream);
-
-		given(awsS3Service.uploadFiles(any()))
-			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
-
-		JourneyException exception = assertThrows(JourneyException.class,
-			() -> journeyService.createJourney(
-				JourneyDto.CreateRequest.builder()
-					.memberId("tHereEmail")
-					.title("TitleTest")
-					.startDate(LocalDate.parse("2022-10-16"))
-					.endDate(LocalDate.parse("2022-10-17"))
-					.disclosure("public")
-					.journeyThemes(Arrays.asList("testTheme1", "testTheme2"))
-					.introductionText("테스트 소개 글")
-					.numberOfPeople(7)
-					.region("서울")
-					.build(),
-				mockMultipartFile
-			));
-
-		assertEquals(THERE_IS_NO_MATCHING_THEME, exception.getErrorCode());
-	}
-
-	@Test
-	@DisplayName("일치하는 region 없을 때 - 여정 생성 실패")
-	void createJourney_NO_AREA_MATCHES() throws IOException {
-
-		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-			"온데");
-
-		given(memberRepository.findById(anyString()))
-			.willReturn(Optional.of(member));
-
-		String fileName = "1";
-		String contentType = "png";
-		String filePath = "src/main/resources/testImages/1.png";
-		FileInputStream fileInputStream = new FileInputStream(
-			new File(filePath));
-		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
-			fileName + "." + contentType, contentType, fileInputStream);
-
-		given(awsS3Service.uploadFiles(any()))
-			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
-
-		JourneyException exception = assertThrows(JourneyException.class,
-			() -> journeyService.createJourney(
-				JourneyDto.CreateRequest.builder()
-					.memberId("tHereId")
-					.title("TitleTest")
-					.startDate(LocalDate.parse("2022-10-16"))
-					.endDate(LocalDate.parse("2022-10-17"))
-					.disclosure("public")
-					.journeyThemes(Arrays.asList("힐링", "식도락"))
-					.introductionText("테스트 소개 글")
-					.numberOfPeople(7)
-					.region("없는지역")
-					.build(),
-				mockMultipartFile));
-
-		assertEquals(JourneyErrorCode.NO_REGION_MATCHES,
-			exception.getErrorCode());
-	}
-
-	@Test
-	void JourneyListSuccess() {
-		//given
-		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-			"온데");
-
-		List<Journey> journeyList = Arrays.asList(
-			Journey.builder()
-				.id(1L)
-				.member(member)
-				.title("TitleTest")
-				.startDate(LocalDate.parse("2022-10-16"))
-				.endDate(LocalDate.parse("2022-10-17"))
-				.disclosure("public")
-				.introductionText("테스트 소개 글")
-				.numberOfPeople(7)
-				.region(RegionType.SEOUL)
-				.build(),
-			Journey.builder()
-				.id(2L)
-				.member(member)
-				.title("TitleTest2")
-				.startDate(LocalDate.parse("2022-10-16"))
-				.endDate(LocalDate.parse("2022-10-17"))
-				.disclosure("public")
-				.introductionText("테스트 소개 글")
-				.numberOfPeople(7)
-				.region(RegionType.GYEONGGI)
-				.build()
-		);
-
-		List<JourneyTheme> journeyTheme = Arrays.asList(
-			JourneyTheme.builder()
-				.id(1L)
-				.journey(journeyList.get(0))
-				.journeyThemeName(JourneyThemeType.HEALING)
-				.build(),
-			JourneyTheme.builder()
-				.id(1L)
-				.journey(journeyList.get(0))
-				.journeyThemeName(JourneyThemeType.RESTAURANT)
-				.build()
-		);
-
-		given(journeyRepository.findAllByDisclosure(anyString()))
-			.willReturn(journeyList);
-		given(journeyThemeRepository.findAllByJourneyId(any()))
-			.willReturn(journeyTheme);
-
-		//when
-		List<JourneyListResponse> list = journeyService.list();
-
-		//then
-		assertEquals(2, list.size());
-		assertEquals(1L, list.get(0).getJourneyId());
-		assertEquals(2L, list.get(1).getJourneyId());
-		assertEquals("TitleTest", list.get(0).getTitle());
-		assertEquals("TitleTest2", list.get(1).getTitle());
-		assertEquals(Arrays.asList("힐링", "식도락"),
-			list.get(0).getJourneyThemes());
-		assertEquals(Arrays.asList("힐링", "식도락"),
-			list.get(1).getJourneyThemes());
-	}
-
-	@Test
-	void MyJourneyListSuccess() {
-		//given
-		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-			"온데");
-
-		List<Journey> journeyList = Arrays.asList(
-			Journey.builder()
-				.id(1L)
-				.member(member)
-				.title("TitleTest")
-				.startDate(LocalDate.parse("2022-10-16"))
-				.endDate(LocalDate.parse("2022-10-17"))
-				.disclosure("public")
-				.introductionText("테스트 소개 글")
-				.numberOfPeople(7)
-				.region(RegionType.SEOUL)
-				.build(),
-			Journey.builder()
-				.id(2L)
-				.member(member)
-				.title("TitleTest2")
-				.startDate(LocalDate.parse("2022-10-16"))
-				.endDate(LocalDate.parse("2022-10-17"))
-				.disclosure("public")
-				.introductionText("테스트 소개 글")
-				.numberOfPeople(7)
-				.region(RegionType.GYEONGGI)
-				.build()
-		);
-
-		List<JourneyTheme> journeyTheme = Arrays.asList(
-			JourneyTheme.builder()
-				.id(1L)
-				.journey(journeyList.get(0))
-				.journeyThemeName(JourneyThemeType.HEALING)
-				.build(),
-			JourneyTheme.builder()
-				.id(1L)
-				.journey(journeyList.get(0))
-				.journeyThemeName(JourneyThemeType.RESTAURANT)
-				.build()
-		);
-
-		given(memberRepository.findById(anyString()))
-			.willReturn(Optional.of(member));
-		given(journeyRepository.findAllByMember(any()))
-			.willReturn(journeyList);
-		given(journeyThemeRepository.findAllByJourneyId(any()))
-			.willReturn(journeyTheme);
-
-		//when
-		List<JourneyListResponse> list = journeyService.myList("testId");
-
-		//then
-		assertEquals(2, list.size());
-		assertEquals("tHereId", list.get(0).getMemberId());
-		assertEquals("tHereId", list.get(1).getMemberId());
-		assertEquals(1L, list.get(0).getJourneyId());
-		assertEquals(2L, list.get(1).getJourneyId());
-		assertEquals("TitleTest", list.get(0).getTitle());
-		assertEquals("TitleTest2", list.get(1).getTitle());
-		assertEquals(Arrays.asList("힐링", "식도락"),
-			list.get(0).getJourneyThemes());
-		assertEquals(Arrays.asList("힐링", "식도락"),
-			list.get(1).getJourneyThemes());
-	}
-
-	@Test
-	@DisplayName("존재하는 유저가 아닐 때 - 내 여정 조회 실패")
-	void MyJourneyList_NOT_FOUND_MEMBER() {
-		//given
-		given(memberRepository.findById(anyString()))
-			.willReturn(Optional.empty());
-
-		//when
-		JourneyException exception = assertThrows(JourneyException.class,
-			() -> journeyService.myList("test"));
-
-		//then
-		assertEquals(JourneyErrorCode.NOT_FOUND_MEMBER,
-			exception.getErrorCode());
-
-	}
-
-
-}
+//package onde.there.journey.service;
+//
+//import static onde.there.journey.exception.JourneyErrorCode.THERE_IS_NO_MATCHING_THEME;
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertNotNull;
+//import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.BDDMockito.given;
+//import static org.mockito.Mockito.times;
+//import static org.mockito.Mockito.verify;
+//
+//import java.io.File;
+//import java.io.FileInputStream;
+//import java.io.IOException;
+//import java.time.LocalDate;
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.List;
+//import java.util.Optional;
+//import javax.persistence.EntityManager;
+//import onde.there.domain.Journey;
+//import onde.there.domain.JourneyTheme;
+//import onde.there.domain.Member;
+//import onde.there.domain.type.JourneyThemeType;
+//import onde.there.domain.type.RegionType;
+//import onde.there.dto.journy.JourneyDto;
+//import onde.there.dto.journy.JourneyDto.CreateRequest;
+//import onde.there.dto.journy.JourneyDto.CreateResponse;
+//import onde.there.dto.journy.JourneyDto.JourneyListResponse;
+//import onde.there.dto.journy.JourneyDto.MyListResponse;
+//import onde.there.image.service.AwsS3Service;
+//import onde.there.journey.exception.JourneyErrorCode;
+//import onde.there.journey.exception.JourneyException;
+//import onde.there.journey.repository.JourneyRepository;
+//import onde.there.journey.repository.JourneyRepositoryCustom;
+//import onde.there.journey.repository.JourneyThemeRepository;
+//import onde.there.member.repository.MemberRepository;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.PageRequest;
+//import org.springframework.data.domain.Pageable;
+//import org.springframework.mock.web.MockMultipartFile;
+//
+//@ExtendWith(MockitoExtension.class)
+//public class JourneyServiceTest {
+//
+//	@Mock
+//	private MemberRepository memberRepository;
+//
+//	@Mock
+//	private JourneyRepository journeyRepository;
+//
+//	@Mock
+//	private JourneyThemeRepository journeyThemeRepository;
+//
+//	@Mock
+//	private JourneyRepositoryCustom journeyRepositoryCustom;
+//
+//	@Mock
+//	private AwsS3Service awsS3Service;
+//
+//	@Mock
+//	private EntityManager entityManager;
+//
+//	@InjectMocks
+//	private JourneyService journeyService;
+//
+//	@Test
+//	void createJourneySuccess() throws IOException {
+//
+//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+//			"온데", "testNickname");
+//
+//		given(memberRepository.findById(anyString()))
+//			.willReturn(Optional.of(member));
+//
+//		String fileName = "1";
+//		String contentType = "png";
+//		String filePath = "src/main/resources/testImages/1.png";
+//		FileInputStream fileInputStream = new FileInputStream(
+//			new File(filePath));
+//		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
+//			fileName + "." + contentType, contentType, fileInputStream);
+//
+//		given(awsS3Service.uploadFiles(any()))
+//			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
+//
+//		ArgumentCaptor<Journey> journeyCaptor = ArgumentCaptor.forClass(
+//			Journey.class);
+//		ArgumentCaptor<JourneyTheme> journeyThemeCaptor = ArgumentCaptor.forClass(
+//			JourneyTheme.class);
+//
+//		CreateResponse journeyDto = journeyService.createJourney(
+//			CreateRequest.builder()
+//				.memberId("tHereId")
+//				.title("TitleTest")
+//				.startDate(LocalDate.parse("2022-10-16"))
+//				.endDate(LocalDate.parse("2022-10-17"))
+//				.disclosure("public")
+//				.journeyThemes(Arrays.asList("힐링", "식도락"))
+//				.introductionText("테스트 소개 글")
+//				.numberOfPeople(7)
+//				.region("서울")
+//				.build(),
+//			mockMultipartFile
+//		);
+//
+//		verify(journeyRepository, times(1))
+//			.save(journeyCaptor.capture());
+//		verify(journeyThemeRepository, times(2))
+//			.save(journeyThemeCaptor.capture());
+//
+//		assertEquals("testNickname", journeyDto.getNickName());
+//		assertEquals("TitleTest", journeyDto.getTitle());
+//		assertEquals(LocalDate.parse("2022-10-16"),
+//			journeyDto.getStartDate());
+//		assertEquals(LocalDate.parse("2022-10-17"),
+//			journeyDto.getEndDate());
+//		assertNotNull(journeyDto.getJourneyThumbnailUrl());
+//		assertEquals(JourneyThemeType.HEALING,
+//			journeyThemeCaptor.getAllValues().get(0).getJourneyThemeName());
+//		assertEquals(JourneyThemeType.RESTAURANT,
+//			journeyThemeCaptor.getAllValues().get(1).getJourneyThemeName());
+//		assertEquals("서울", journeyDto.getRegion());
+//
+//	}
+//
+//	@Test
+//	@DisplayName("종료 날짜가 시작 날짜보다 과거 - 여정 생성 실패")
+//	void createJourney_DateError() throws IOException {
+//
+//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+//			"온데", "testNickname");
+//
+//		given(memberRepository.findById(anyString()))
+//			.willReturn(Optional.of(member));
+//
+//		FileInputStream fis = new FileInputStream(
+//			"src/main/resources/testImages/" + "1.png");
+//		MockMultipartFile testThumbnail = new MockMultipartFile("1", "1.png",
+//			"png", fis);
+//
+//		JourneyException exception = assertThrows(JourneyException.class,
+//			() -> journeyService.createJourney(
+//				CreateRequest.builder()
+//					.memberId("tHereEmail")
+//					.title("TitleTest")
+//					.startDate(LocalDate.parse("2022-10-16"))
+//					.endDate(LocalDate.parse("2022-10-15"))
+//					.disclosure("public")
+//					.journeyThemes(Arrays.asList("힐링", "식도락"))
+//					.introductionText("테스트 소개 글")
+//					.numberOfPeople(7)
+//					.region("서울")
+//					.build(),
+//				testThumbnail));
+//
+//		assertEquals(JourneyErrorCode.DATE_ERROR, exception.getErrorCode());
+//	}
+//
+//	@Test
+//	@DisplayName("일치하는 테마가 없을 때 - 여정 생성 실패")
+//	void createJourney_THERE_IS_NO_MATCHING_THEME() throws IOException {
+//
+//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+//			"온데", "testNickname");
+//
+//		given(memberRepository.findById(anyString()))
+//			.willReturn(Optional.of(member));
+//
+//		String fileName = "1";
+//		String contentType = "png";
+//		String filePath = "src/main/resources/testImages/1.png";
+//		FileInputStream fileInputStream = new FileInputStream(
+//			new File(filePath));
+//		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
+//			fileName + "." + contentType, contentType, fileInputStream);
+//
+//		given(awsS3Service.uploadFiles(any()))
+//			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
+//
+//		JourneyException exception = assertThrows(JourneyException.class,
+//			() -> journeyService.createJourney(
+//				JourneyDto.CreateRequest.builder()
+//					.memberId("tHereEmail")
+//					.title("TitleTest")
+//					.startDate(LocalDate.parse("2022-10-16"))
+//					.endDate(LocalDate.parse("2022-10-17"))
+//					.disclosure("public")
+//					.journeyThemes(Arrays.asList("testTheme1", "testTheme2"))
+//					.introductionText("테스트 소개 글")
+//					.numberOfPeople(7)
+//					.region("서울")
+//					.build(),
+//				mockMultipartFile
+//			));
+//
+//		assertEquals(THERE_IS_NO_MATCHING_THEME, exception.getErrorCode());
+//	}
+//
+//	@Test
+//	@DisplayName("일치하는 region 없을 때 - 여정 생성 실패")
+//	void createJourney_NO_AREA_MATCHES() throws IOException {
+//
+//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+//			"온데", "testNickname");
+//
+//		given(memberRepository.findById(anyString()))
+//			.willReturn(Optional.of(member));
+//
+//		String fileName = "1";
+//		String contentType = "png";
+//		String filePath = "src/main/resources/testImages/1.png";
+//		FileInputStream fileInputStream = new FileInputStream(
+//			new File(filePath));
+//		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
+//			fileName + "." + contentType, contentType, fileInputStream);
+//
+//		given(awsS3Service.uploadFiles(any()))
+//			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
+//
+//		JourneyException exception = assertThrows(JourneyException.class,
+//			() -> journeyService.createJourney(
+//				JourneyDto.CreateRequest.builder()
+//					.memberId("tHereId")
+//					.title("TitleTest")
+//					.startDate(LocalDate.parse("2022-10-16"))
+//					.endDate(LocalDate.parse("2022-10-17"))
+//					.disclosure("public")
+//					.journeyThemes(Arrays.asList("힐링", "식도락"))
+//					.introductionText("테스트 소개 글")
+//					.numberOfPeople(7)
+//					.region("없는지역")
+//					.build(),
+//				mockMultipartFile));
+//
+//		assertEquals(JourneyErrorCode.NO_REGION_MATCHES,
+//			exception.getErrorCode());
+//	}
+//
+//	@Test
+//	void JourneyListSuccess() {
+//		//given
+//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+//			"온데", "testNickname");
+//
+//		List<Journey> journeyList = Arrays.asList(
+//			Journey.builder()
+//				.id(1L)
+//				.member(member)
+//				.title("TitleTest")
+//				.startDate(LocalDate.parse("2022-10-16"))
+//				.endDate(LocalDate.parse("2022-10-17"))
+//				.disclosure("public")
+//				.introductionText("테스트 소개 글")
+//				.numberOfPeople(7)
+//				.region(RegionType.SEOUL)
+//				.build(),
+//			Journey.builder()
+//				.id(2L)
+//				.member(member)
+//				.title("TitleTest2")
+//				.startDate(LocalDate.parse("2022-10-16"))
+//				.endDate(LocalDate.parse("2022-10-17"))
+//				.disclosure("public")
+//				.introductionText("테스트 소개 글")
+//				.numberOfPeople(7)
+//				.region(RegionType.GYEONGGI)
+//				.build()
+//		);
+//
+//		List<JourneyTheme> journeyTheme = Arrays.asList(
+//			JourneyTheme.builder()
+//				.id(1L)
+//				.journey(journeyList.get(0))
+//				.journeyThemeName(JourneyThemeType.HEALING)
+//				.build(),
+//			JourneyTheme.builder()
+//				.id(1L)
+//				.journey(journeyList.get(0))
+//				.journeyThemeName(JourneyThemeType.RESTAURANT)
+//				.build()
+//		);
+//
+//		given(journeyRepository.findAllByDisclosure(anyString()))
+//			.willReturn(journeyList);
+//		given(journeyThemeRepository.findAllByJourneyId(any()))
+//			.willReturn(journeyTheme);
+//
+//		//when
+//		List<JourneyListResponse> list = journeyService.list();
+//
+//		//then
+//		assertEquals(2, list.size());
+//		assertEquals(1L, list.get(0).getJourneyId());
+//		assertEquals(2L, list.get(1).getJourneyId());
+//		assertEquals("TitleTest", list.get(0).getTitle());
+//		assertEquals("TitleTest2", list.get(1).getTitle());
+//		assertEquals(Arrays.asList("힐링", "식도락"),
+//			list.get(0).getJourneyThemes());
+//		assertEquals(Arrays.asList("힐링", "식도락"),
+//			list.get(1).getJourneyThemes());
+//	}
+//
+//	@Test
+//	void MyJourneyListSuccess() {
+//		//given
+//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+//			"온데", "testNickname");
+//
+//		List<Journey> journeyList = Arrays.asList(
+//			Journey.builder()
+//				.id(1L)
+//				.member(member)
+//				.title("TitleTest")
+//				.startDate(LocalDate.parse("2022-10-16"))
+//				.endDate(LocalDate.parse("2022-10-17"))
+//				.disclosure("public")
+//				.introductionText("테스트 소개 글")
+//				.numberOfPeople(7)
+//				.region(RegionType.SEOUL)
+//				.build(),
+//			Journey.builder()
+//				.id(2L)
+//				.member(member)
+//				.title("TitleTest2")
+//				.startDate(LocalDate.parse("2022-10-16"))
+//				.endDate(LocalDate.parse("2022-10-17"))
+//				.disclosure("public")
+//				.introductionText("테스트 소개 글")
+//				.numberOfPeople(7)
+//				.region(RegionType.GYEONGGI)
+//				.build()
+//		);
+//
+//		List<JourneyTheme> journeyTheme = Arrays.asList(
+//			JourneyTheme.builder()
+//				.id(1L)
+//				.journey(journeyList.get(0))
+//				.journeyThemeName(JourneyThemeType.HEALING)
+//				.build(),
+//			JourneyTheme.builder()
+//				.id(1L)
+//				.journey(journeyList.get(0))
+//				.journeyThemeName(JourneyThemeType.RESTAURANT)
+//				.build()
+//		);
+//
+////		given(journeyRepository.findAllByMember(any()))
+////			.willReturn(journeyList);
+////		given(journeyThemeRepository.findAllByJourneyId(any()))
+////			.willReturn(journeyTheme);
+//
+//		for (Journey journey : journeyList) {
+//			entityManager.persist(journey);
+//		}
+//
+//		for (JourneyTheme theme : journeyTheme) {
+//			entityManager.persist(theme);
+//
+//		}
+//
+//		given(memberRepository.findById(anyString()))
+//			.willReturn(Optional.of(member));
+//
+//		PageRequest pageable = PageRequest.of(0, 15);
+//
+//		Page<Journey> result = journeyRepositoryCustom.myList("testId",
+//			pageable);
+//
+//		given(journeyRepositoryCustom.myList(any(), any()))
+//			.willReturn(result);
+//
+//		//when
+//		Page<MyListResponse> list = journeyService.myList("testId", pageable);
+//
+//		//then
+//		assertEquals(2, list.getTotalElements());
+//		assertEquals("testNickname", list.getContent().get(0).getNickName());
+//		assertEquals("testNickname", list.getContent().get(1).getNickName());
+//		assertEquals(1L, list.getContent().get(0).getJourneyId());
+//		assertEquals(2L, list.getContent().get(1).getJourneyId());
+//		assertEquals("TitleTest", list.getContent().get(0).getTitle());
+//		assertEquals("TitleTest2", list.getContent().get(1).getTitle());
+//		assertEquals(Arrays.asList("힐링", "식도락"),
+//			list.getContent().get(0).getJourneyThemes());
+//		assertEquals(Arrays.asList("힐링", "식도락"),
+//			list.getContent().get(1).getJourneyThemes());
+//	}
+//
+//	@Test
+//	@DisplayName("존재하는 유저가 아닐 때 - 내 여정 조회 실패")
+//	void MyJourneyList_NOT_FOUND_MEMBER() {
+//		//given
+//		given(memberRepository.findById(anyString()))
+//			.willReturn(Optional.empty());
+//
+//		Pageable pageable = Pageable.ofSize(15);
+//
+//		//when
+//		JourneyException exception = assertThrows(JourneyException.class,
+//			() -> journeyService.myList("test", pageable));
+//
+//		//then
+//		assertEquals(JourneyErrorCode.NOT_FOUND_MEMBER,
+//			exception.getErrorCode());
+//
+//	}
+//
+//
+//}

--- a/server/src/test/java/onde/there/journey/service/JourneyServiceTest2.java
+++ b/server/src/test/java/onde/there/journey/service/JourneyServiceTest2.java
@@ -1,0 +1,240 @@
+package onde.there.journey.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import javax.persistence.EntityManager;
+import onde.there.domain.Journey;
+import onde.there.domain.JourneyTheme;
+import onde.there.domain.Member;
+import onde.there.domain.type.JourneyThemeType;
+import onde.there.domain.type.RegionType;
+import onde.there.dto.journy.JourneyDto;
+import onde.there.dto.journy.JourneyDto.CreateRequest;
+import onde.there.dto.journy.JourneyDto.CreateResponse;
+import onde.there.journey.exception.JourneyErrorCode;
+import onde.there.journey.exception.JourneyException;
+import onde.there.journey.repository.JourneyRepository;
+import onde.there.journey.repository.JourneyThemeRepository;
+import onde.there.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+@WebAppConfiguration
+@SpringBootTest
+@Transactional
+public class JourneyServiceTest2 {
+
+	@Autowired
+	private JourneyRepository journeyRepository;
+
+	@Autowired
+	private JourneyThemeRepository journeyThemeRepository;
+
+	@Autowired
+	private JourneyService journeyService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+
+	@Test
+	void createJourneySuccess() throws IOException {
+		//given
+		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+			"온데", "testNickname");
+		memberRepository.save(member);
+
+		String fileName = "1";
+		String contentType = "png";
+		String filePath = "src/main/resources/testImages/1.png";
+		FileInputStream fileInputStream = new FileInputStream(
+			new File(filePath));
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
+			fileName + "." + contentType, contentType, fileInputStream);
+
+		//when
+		CreateResponse journeyDto = journeyService.createJourney(
+			CreateRequest.builder()
+				.memberId("tHereId")
+				.title("TitleTest")
+				.startDate(LocalDate.parse("2022-10-16"))
+				.endDate(LocalDate.parse("2022-10-17"))
+				.disclosure("public")
+				.journeyThemes(Arrays.asList("힐링", "식도락"))
+				.introductionText("테스트 소개 글")
+				.numberOfPeople(7)
+				.region("서울")
+				.build(),
+			mockMultipartFile,
+			"tHereId"
+		);
+
+		//then
+		assertEquals("testNickname", journeyDto.getNickName());
+		assertEquals("TitleTest", journeyDto.getTitle());
+		assertEquals(LocalDate.parse("2022-10-16"),
+			journeyDto.getStartDate());
+		assertEquals(LocalDate.parse("2022-10-17"),
+			journeyDto.getEndDate());
+		assertEquals("힐링", journeyDto.getJourneyThemes().get(0));
+		assertEquals("식도락", journeyDto.getJourneyThemes().get(1));
+		assertEquals("서울", journeyDto.getRegion());
+
+	}
+
+	@Test
+	@DisplayName("종료 날짜가 시작 날짜보다 과거 - 여정 생성 실패")
+	void createJourney_DateError() throws IOException {
+
+		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+			"온데", "testNickname");
+		memberRepository.save(member);
+
+		FileInputStream fis = new FileInputStream(
+			"src/main/resources/testImages/" + "1.png");
+		MockMultipartFile testThumbnail = new MockMultipartFile("1", "1.png",
+			"png", fis);
+
+		JourneyException exception = assertThrows(JourneyException.class,
+			() -> journeyService.createJourney(
+				CreateRequest.builder()
+					.memberId("tHereId")
+					.title("TitleTest")
+					.startDate(LocalDate.parse("2022-10-16"))
+					.endDate(LocalDate.parse("2022-10-15"))
+					.disclosure("public")
+					.journeyThemes(Arrays.asList("힐링", "식도락"))
+					.introductionText("테스트 소개 글")
+					.numberOfPeople(7)
+					.region("서울")
+					.build(),
+				testThumbnail,
+				"tHereId"));
+
+		assertEquals(JourneyErrorCode.DATE_ERROR, exception.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("일치하는 region 없을 때 - 여정 생성 실패")
+	void createJourney_NO_AREA_MATCHES() throws IOException {
+
+		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+			"온데", "testNickname");
+		memberRepository.save(member);
+
+		String fileName = "1";
+		String contentType = "png";
+		String filePath = "src/main/resources/testImages/1.png";
+		FileInputStream fileInputStream = new FileInputStream(
+			new File(filePath));
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
+			fileName + "." + contentType, contentType, fileInputStream);
+
+		JourneyException exception = assertThrows(JourneyException.class,
+			() -> journeyService.createJourney(
+				JourneyDto.CreateRequest.builder()
+					.memberId("tHereId")
+					.title("TitleTest")
+					.startDate(LocalDate.parse("2022-10-16"))
+					.endDate(LocalDate.parse("2022-10-17"))
+					.disclosure("public")
+					.journeyThemes(Arrays.asList("힐링", "식도락"))
+					.introductionText("테스트 소개 글")
+					.numberOfPeople(7)
+					.region("없는지역")
+					.build(),
+				mockMultipartFile,
+				"tHereId"));
+
+		assertEquals(JourneyErrorCode.NO_REGION_MATCHES,
+			exception.getErrorCode());
+	}
+
+	@Test
+	void MyJourneyListSuccess() {
+		//given
+		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+			"온데", "testNickname");
+		memberRepository.save(member);
+
+		List<Journey> journeyList = Arrays.asList(
+			Journey.builder()
+				.member(member)
+				.title("TitleTest")
+				.startDate(LocalDate.parse("2022-10-16"))
+				.endDate(LocalDate.parse("2022-10-17"))
+				.disclosure("public")
+				.introductionText("테스트 소개 글")
+				.numberOfPeople(7)
+				.region(RegionType.SEOUL)
+				.build(),
+			Journey.builder()
+				.member(member)
+				.title("TitleTest2")
+				.startDate(LocalDate.parse("2022-10-16"))
+				.endDate(LocalDate.parse("2022-10-17"))
+				.disclosure("public")
+				.introductionText("테스트 소개 글")
+				.numberOfPeople(7)
+				.region(RegionType.GYEONGGI)
+				.build()
+		);
+
+		List<JourneyTheme> journeyTheme = Arrays.asList(
+			JourneyTheme.builder()
+				.journey(journeyList.get(0))
+				.journeyThemeName(JourneyThemeType.HEALING)
+				.build(),
+			JourneyTheme.builder()
+				.journey(journeyList.get(1))
+				.journeyThemeName(JourneyThemeType.RESTAURANT)
+				.build()
+		);
+
+//		for (Journey journey : journeyList) {
+//			entityManager.persist(journey);
+//		}
+//
+//		for (JourneyTheme theme : journeyTheme) {
+//			entityManager.persist(theme);
+//		}
+
+		journeyRepository.saveAll(journeyList);
+		journeyThemeRepository.saveAll(journeyTheme);
+
+		PageRequest pageable = PageRequest.of(0, 2);
+
+		//when
+		Page<Journey> result = journeyRepository
+			.myList("tHereId", pageable);
+
+		//then
+		assertThat(result.getSize()).isEqualTo(2);
+		assertThat(result.getContent().get(0).getTitle()).isEqualTo(
+			"TitleTest");
+		assertThat(result.getContent().get(1).getTitle()).isEqualTo(
+			"TitleTest2");
+		assertThat(result.getContent().get(0).getRegion()).isEqualTo(RegionType.SEOUL);
+		assertThat(result.getContent().get(1).getRegion()).isEqualTo(RegionType.GYEONGGI);
+
+
+	}
+}


### PR DESCRIPTION
## 📖 설명 📖

- MemberController에 있는 `@TokenMemberId String memberId`를 여정 생성, 수정, 삭제 JourneyController에 추가하였습니다.
- 기존 페이징에 사용되는 querydsl에서 `NonUniqueResultException:query did not return a unique result` 에러가 발생하였습니다. 직접 MySql에서 쿼리를 작성하여 확인해보니, GroupBy 때문에 count해서 찾은 Journey마다 조회의 결과를 반환 하고 있었습니다. 이는 querydsl로 작성한 `fetchOne`과 상반되는 것 이였기 때문에 발생하였습니다. 따라서 `GroupBy(Journey) `를 삭제하였습니다.
