### PR TITLE
Refactor : Journey 페이징 처리 에러해결-2, querydsl 최적화

### DIFF
--- a/server/src/main/java/onde/there/journey/repository/JourneyRepositoryImpl.java
+++ b/server/src/main/java/onde/there/journey/repository/JourneyRepositoryImpl.java
@@ -2,6 +2,7 @@ package onde.there.journey.repository;
 
 import static onde.there.domain.QJourney.journey;
 import static onde.there.domain.QJourneyTheme.journeyTheme;
+import static onde.there.domain.QMember.*;
 import static onde.there.domain.type.JourneyThemeType.findByTheme;
 import static onde.there.domain.type.RegionType.findByRegion;
 
@@ -10,6 +11,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import onde.there.domain.Journey;
 import onde.there.dto.journy.JourneyDto;
@@ -35,6 +37,8 @@ public class JourneyRepositoryImpl implements JourneyRepositoryCustom {
 		List<Journey> content = jpaQueryFactory
 			.selectFrom(journey)
 			.innerJoin(journey.journeyThemes, journeyTheme)
+			.innerJoin(journey.member, member)
+			.fetchJoin()
 			.where(
 				journey.disclosure.eq("public"),
 				filteredRegion,
@@ -47,7 +51,7 @@ public class JourneyRepositoryImpl implements JourneyRepositoryCustom {
 			.fetch();
 
 		JPAQuery<Long> countQuery = jpaQueryFactory
-			.select(journey.count())
+			.select(journey.countDistinct())
 			.from(journey)
 			.innerJoin(journey.journeyThemes, journeyTheme)
 			.where(
@@ -66,6 +70,8 @@ public class JourneyRepositoryImpl implements JourneyRepositoryCustom {
 		List<Journey> content = jpaQueryFactory
 			.selectFrom(journey)
 			.innerJoin(journey.journeyThemes, journeyTheme)
+			.innerJoin(journey.member, member)
+			.fetchJoin()
 			.where(eqMemberId(memberId))
 			.groupBy(journey)
 			.offset(pageable.getOffset())
@@ -73,7 +79,7 @@ public class JourneyRepositoryImpl implements JourneyRepositoryCustom {
 			.fetch();
 
 		JPAQuery<Long> countQuery = jpaQueryFactory
-			.select(journey.count())
+			.select(journey.countDistinct())
 			.from(journey)
 			.innerJoin(journey.journeyThemes, journeyTheme)
 			.where(eqMemberId(memberId));
@@ -83,6 +89,10 @@ public class JourneyRepositoryImpl implements JourneyRepositoryCustom {
 	}
 
 	private BooleanExpression eqTitle(String title) {
+
+		if (Objects.equals(title, "")) {
+			return null;
+		}
 
 		return title == null ? null : journey.title.contains(title);
 	}

--- a/server/src/main/java/onde/there/journey/service/JourneyService.java
+++ b/server/src/main/java/onde/there/journey/service/JourneyService.java
@@ -34,7 +34,6 @@ import onde.there.place.exception.PlaceErrorCode;
 import onde.there.place.exception.PlaceException;
 import onde.there.place.repository.PlaceRepository;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -126,14 +125,13 @@ public class JourneyService {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new JourneyException(NOT_FOUND_MEMBER));
 
-		PageImpl<MyListResponse> MyListResponses = new PageImpl<>(
-			journeyRepository.myList(memberId, pageable).stream()
-				.map(MyListResponse::fromEntity).collect(
-					Collectors.toList()));
+		Page<Journey> journeys = journeyRepository.myList(memberId, pageable);
 
 		log.info("myList() : 조회 완료");
 
-		return MyListResponses;
+		return journeys.map(
+			MyListResponse::fromEntity
+		);
 	}
 
 	@Transactional
@@ -142,14 +140,14 @@ public class JourneyService {
 
 		log.info("filteredList() : 호출");
 
-		PageImpl<FilteringResponse> filteringResponses = new PageImpl<>(
-			journeyRepository.searchAll(filteringRequest, pageable).stream()
-				.map(FilteringResponse::fromEntity).collect(
-					Collectors.toList()));
+		Page<Journey> journeys = journeyRepository.searchAll(filteringRequest,
+			pageable);
 
 		log.info("filteredList() : 종료");
 
-		return filteringResponses;
+		return journeys.map(
+			FilteringResponse::fromEntity
+		);
 
 	}
 

--- a/server/src/test/java/onde/there/journey/service/JourneyServiceTest.java
+++ b/server/src/test/java/onde/there/journey/service/JourneyServiceTest.java
@@ -1,418 +1,335 @@
-//package onde.there.journey.service;
-//
-//import static onde.there.journey.exception.JourneyErrorCode.THERE_IS_NO_MATCHING_THEME;
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertNotNull;
-//import static org.junit.jupiter.api.Assertions.assertThrows;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.BDDMockito.given;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//
-//import java.io.File;
-//import java.io.FileInputStream;
-//import java.io.IOException;
-//import java.time.LocalDate;
-//import java.util.ArrayList;
-//import java.util.Arrays;
-//import java.util.List;
-//import java.util.Optional;
-//import javax.persistence.EntityManager;
-//import onde.there.domain.Journey;
-//import onde.there.domain.JourneyTheme;
-//import onde.there.domain.Member;
-//import onde.there.domain.type.JourneyThemeType;
-//import onde.there.domain.type.RegionType;
-//import onde.there.dto.journy.JourneyDto;
-//import onde.there.dto.journy.JourneyDto.CreateRequest;
-//import onde.there.dto.journy.JourneyDto.CreateResponse;
-//import onde.there.dto.journy.JourneyDto.JourneyListResponse;
-//import onde.there.dto.journy.JourneyDto.MyListResponse;
-//import onde.there.image.service.AwsS3Service;
-//import onde.there.journey.exception.JourneyErrorCode;
-//import onde.there.journey.exception.JourneyException;
-//import onde.there.journey.repository.JourneyRepository;
-//import onde.there.journey.repository.JourneyRepositoryCustom;
-//import onde.there.journey.repository.JourneyThemeRepository;
-//import onde.there.member.repository.MemberRepository;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.domain.Page;
-//import org.springframework.data.domain.PageRequest;
-//import org.springframework.data.domain.Pageable;
-//import org.springframework.mock.web.MockMultipartFile;
-//
-//@ExtendWith(MockitoExtension.class)
-//public class JourneyServiceTest {
-//
-//	@Mock
-//	private MemberRepository memberRepository;
-//
-//	@Mock
-//	private JourneyRepository journeyRepository;
-//
-//	@Mock
-//	private JourneyThemeRepository journeyThemeRepository;
-//
-//	@Mock
-//	private JourneyRepositoryCustom journeyRepositoryCustom;
-//
-//	@Mock
-//	private AwsS3Service awsS3Service;
-//
-//	@Mock
-//	private EntityManager entityManager;
-//
-//	@InjectMocks
-//	private JourneyService journeyService;
-//
-//	@Test
-//	void createJourneySuccess() throws IOException {
-//
-//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-//			"온데", "testNickname");
-//
-//		given(memberRepository.findById(anyString()))
-//			.willReturn(Optional.of(member));
-//
-//		String fileName = "1";
-//		String contentType = "png";
-//		String filePath = "src/main/resources/testImages/1.png";
-//		FileInputStream fileInputStream = new FileInputStream(
-//			new File(filePath));
-//		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
-//			fileName + "." + contentType, contentType, fileInputStream);
-//
-//		given(awsS3Service.uploadFiles(any()))
-//			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
-//
-//		ArgumentCaptor<Journey> journeyCaptor = ArgumentCaptor.forClass(
-//			Journey.class);
-//		ArgumentCaptor<JourneyTheme> journeyThemeCaptor = ArgumentCaptor.forClass(
-//			JourneyTheme.class);
-//
-//		CreateResponse journeyDto = journeyService.createJourney(
-//			CreateRequest.builder()
-//				.memberId("tHereId")
-//				.title("TitleTest")
-//				.startDate(LocalDate.parse("2022-10-16"))
-//				.endDate(LocalDate.parse("2022-10-17"))
-//				.disclosure("public")
-//				.journeyThemes(Arrays.asList("힐링", "식도락"))
-//				.introductionText("테스트 소개 글")
-//				.numberOfPeople(7)
-//				.region("서울")
-//				.build(),
-//			mockMultipartFile
-//		);
-//
-//		verify(journeyRepository, times(1))
-//			.save(journeyCaptor.capture());
-//		verify(journeyThemeRepository, times(2))
-//			.save(journeyThemeCaptor.capture());
-//
-//		assertEquals("testNickname", journeyDto.getNickName());
-//		assertEquals("TitleTest", journeyDto.getTitle());
-//		assertEquals(LocalDate.parse("2022-10-16"),
-//			journeyDto.getStartDate());
-//		assertEquals(LocalDate.parse("2022-10-17"),
-//			journeyDto.getEndDate());
-//		assertNotNull(journeyDto.getJourneyThumbnailUrl());
-//		assertEquals(JourneyThemeType.HEALING,
-//			journeyThemeCaptor.getAllValues().get(0).getJourneyThemeName());
-//		assertEquals(JourneyThemeType.RESTAURANT,
-//			journeyThemeCaptor.getAllValues().get(1).getJourneyThemeName());
-//		assertEquals("서울", journeyDto.getRegion());
-//
-//	}
-//
-//	@Test
-//	@DisplayName("종료 날짜가 시작 날짜보다 과거 - 여정 생성 실패")
-//	void createJourney_DateError() throws IOException {
-//
-//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-//			"온데", "testNickname");
-//
-//		given(memberRepository.findById(anyString()))
-//			.willReturn(Optional.of(member));
-//
-//		FileInputStream fis = new FileInputStream(
-//			"src/main/resources/testImages/" + "1.png");
-//		MockMultipartFile testThumbnail = new MockMultipartFile("1", "1.png",
-//			"png", fis);
-//
-//		JourneyException exception = assertThrows(JourneyException.class,
-//			() -> journeyService.createJourney(
-//				CreateRequest.builder()
-//					.memberId("tHereEmail")
-//					.title("TitleTest")
-//					.startDate(LocalDate.parse("2022-10-16"))
-//					.endDate(LocalDate.parse("2022-10-15"))
-//					.disclosure("public")
-//					.journeyThemes(Arrays.asList("힐링", "식도락"))
-//					.introductionText("테스트 소개 글")
-//					.numberOfPeople(7)
-//					.region("서울")
-//					.build(),
-//				testThumbnail));
-//
-//		assertEquals(JourneyErrorCode.DATE_ERROR, exception.getErrorCode());
-//	}
-//
-//	@Test
-//	@DisplayName("일치하는 테마가 없을 때 - 여정 생성 실패")
-//	void createJourney_THERE_IS_NO_MATCHING_THEME() throws IOException {
-//
-//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-//			"온데", "testNickname");
-//
-//		given(memberRepository.findById(anyString()))
-//			.willReturn(Optional.of(member));
-//
-//		String fileName = "1";
-//		String contentType = "png";
-//		String filePath = "src/main/resources/testImages/1.png";
-//		FileInputStream fileInputStream = new FileInputStream(
-//			new File(filePath));
-//		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
-//			fileName + "." + contentType, contentType, fileInputStream);
-//
-//		given(awsS3Service.uploadFiles(any()))
-//			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
-//
-//		JourneyException exception = assertThrows(JourneyException.class,
-//			() -> journeyService.createJourney(
-//				JourneyDto.CreateRequest.builder()
-//					.memberId("tHereEmail")
-//					.title("TitleTest")
-//					.startDate(LocalDate.parse("2022-10-16"))
-//					.endDate(LocalDate.parse("2022-10-17"))
-//					.disclosure("public")
-//					.journeyThemes(Arrays.asList("testTheme1", "testTheme2"))
-//					.introductionText("테스트 소개 글")
-//					.numberOfPeople(7)
-//					.region("서울")
-//					.build(),
-//				mockMultipartFile
-//			));
-//
-//		assertEquals(THERE_IS_NO_MATCHING_THEME, exception.getErrorCode());
-//	}
-//
-//	@Test
-//	@DisplayName("일치하는 region 없을 때 - 여정 생성 실패")
-//	void createJourney_NO_AREA_MATCHES() throws IOException {
-//
-//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-//			"온데", "testNickname");
-//
-//		given(memberRepository.findById(anyString()))
-//			.willReturn(Optional.of(member));
-//
-//		String fileName = "1";
-//		String contentType = "png";
-//		String filePath = "src/main/resources/testImages/1.png";
-//		FileInputStream fileInputStream = new FileInputStream(
-//			new File(filePath));
-//		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
-//			fileName + "." + contentType, contentType, fileInputStream);
-//
-//		given(awsS3Service.uploadFiles(any()))
-//			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
-//
-//		JourneyException exception = assertThrows(JourneyException.class,
-//			() -> journeyService.createJourney(
-//				JourneyDto.CreateRequest.builder()
-//					.memberId("tHereId")
-//					.title("TitleTest")
-//					.startDate(LocalDate.parse("2022-10-16"))
-//					.endDate(LocalDate.parse("2022-10-17"))
-//					.disclosure("public")
-//					.journeyThemes(Arrays.asList("힐링", "식도락"))
-//					.introductionText("테스트 소개 글")
-//					.numberOfPeople(7)
-//					.region("없는지역")
-//					.build(),
-//				mockMultipartFile));
-//
-//		assertEquals(JourneyErrorCode.NO_REGION_MATCHES,
-//			exception.getErrorCode());
-//	}
-//
-//	@Test
-//	void JourneyListSuccess() {
-//		//given
-//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-//			"온데", "testNickname");
-//
-//		List<Journey> journeyList = Arrays.asList(
-//			Journey.builder()
-//				.id(1L)
-//				.member(member)
-//				.title("TitleTest")
-//				.startDate(LocalDate.parse("2022-10-16"))
-//				.endDate(LocalDate.parse("2022-10-17"))
-//				.disclosure("public")
-//				.introductionText("테스트 소개 글")
-//				.numberOfPeople(7)
-//				.region(RegionType.SEOUL)
-//				.build(),
-//			Journey.builder()
-//				.id(2L)
-//				.member(member)
-//				.title("TitleTest2")
-//				.startDate(LocalDate.parse("2022-10-16"))
-//				.endDate(LocalDate.parse("2022-10-17"))
-//				.disclosure("public")
-//				.introductionText("테스트 소개 글")
-//				.numberOfPeople(7)
-//				.region(RegionType.GYEONGGI)
-//				.build()
-//		);
-//
-//		List<JourneyTheme> journeyTheme = Arrays.asList(
-//			JourneyTheme.builder()
-//				.id(1L)
-//				.journey(journeyList.get(0))
-//				.journeyThemeName(JourneyThemeType.HEALING)
-//				.build(),
-//			JourneyTheme.builder()
-//				.id(1L)
-//				.journey(journeyList.get(0))
-//				.journeyThemeName(JourneyThemeType.RESTAURANT)
-//				.build()
-//		);
-//
-//		given(journeyRepository.findAllByDisclosure(anyString()))
-//			.willReturn(journeyList);
-//		given(journeyThemeRepository.findAllByJourneyId(any()))
-//			.willReturn(journeyTheme);
-//
-//		//when
-//		List<JourneyListResponse> list = journeyService.list();
-//
-//		//then
-//		assertEquals(2, list.size());
-//		assertEquals(1L, list.get(0).getJourneyId());
-//		assertEquals(2L, list.get(1).getJourneyId());
-//		assertEquals("TitleTest", list.get(0).getTitle());
-//		assertEquals("TitleTest2", list.get(1).getTitle());
-//		assertEquals(Arrays.asList("힐링", "식도락"),
-//			list.get(0).getJourneyThemes());
-//		assertEquals(Arrays.asList("힐링", "식도락"),
-//			list.get(1).getJourneyThemes());
-//	}
-//
-//	@Test
-//	void MyJourneyListSuccess() {
-//		//given
-//		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
-//			"온데", "testNickname");
-//
-//		List<Journey> journeyList = Arrays.asList(
-//			Journey.builder()
-//				.id(1L)
-//				.member(member)
-//				.title("TitleTest")
-//				.startDate(LocalDate.parse("2022-10-16"))
-//				.endDate(LocalDate.parse("2022-10-17"))
-//				.disclosure("public")
-//				.introductionText("테스트 소개 글")
-//				.numberOfPeople(7)
-//				.region(RegionType.SEOUL)
-//				.build(),
-//			Journey.builder()
-//				.id(2L)
-//				.member(member)
-//				.title("TitleTest2")
-//				.startDate(LocalDate.parse("2022-10-16"))
-//				.endDate(LocalDate.parse("2022-10-17"))
-//				.disclosure("public")
-//				.introductionText("테스트 소개 글")
-//				.numberOfPeople(7)
-//				.region(RegionType.GYEONGGI)
-//				.build()
-//		);
-//
-//		List<JourneyTheme> journeyTheme = Arrays.asList(
-//			JourneyTheme.builder()
-//				.id(1L)
-//				.journey(journeyList.get(0))
-//				.journeyThemeName(JourneyThemeType.HEALING)
-//				.build(),
-//			JourneyTheme.builder()
-//				.id(1L)
-//				.journey(journeyList.get(0))
-//				.journeyThemeName(JourneyThemeType.RESTAURANT)
-//				.build()
-//		);
-//
-////		given(journeyRepository.findAllByMember(any()))
-////			.willReturn(journeyList);
-////		given(journeyThemeRepository.findAllByJourneyId(any()))
-////			.willReturn(journeyTheme);
-//
-//		for (Journey journey : journeyList) {
-//			entityManager.persist(journey);
-//		}
-//
-//		for (JourneyTheme theme : journeyTheme) {
-//			entityManager.persist(theme);
-//
-//		}
-//
-//		given(memberRepository.findById(anyString()))
-//			.willReturn(Optional.of(member));
-//
-//		PageRequest pageable = PageRequest.of(0, 15);
-//
-//		Page<Journey> result = journeyRepositoryCustom.myList("testId",
-//			pageable);
-//
-//		given(journeyRepositoryCustom.myList(any(), any()))
-//			.willReturn(result);
-//
-//		//when
-//		Page<MyListResponse> list = journeyService.myList("testId", pageable);
-//
-//		//then
-//		assertEquals(2, list.getTotalElements());
-//		assertEquals("testNickname", list.getContent().get(0).getNickName());
-//		assertEquals("testNickname", list.getContent().get(1).getNickName());
-//		assertEquals(1L, list.getContent().get(0).getJourneyId());
-//		assertEquals(2L, list.getContent().get(1).getJourneyId());
-//		assertEquals("TitleTest", list.getContent().get(0).getTitle());
-//		assertEquals("TitleTest2", list.getContent().get(1).getTitle());
-//		assertEquals(Arrays.asList("힐링", "식도락"),
-//			list.getContent().get(0).getJourneyThemes());
-//		assertEquals(Arrays.asList("힐링", "식도락"),
-//			list.getContent().get(1).getJourneyThemes());
-//	}
-//
-//	@Test
-//	@DisplayName("존재하는 유저가 아닐 때 - 내 여정 조회 실패")
-//	void MyJourneyList_NOT_FOUND_MEMBER() {
-//		//given
-//		given(memberRepository.findById(anyString()))
-//			.willReturn(Optional.empty());
-//
-//		Pageable pageable = Pageable.ofSize(15);
-//
-//		//when
-//		JourneyException exception = assertThrows(JourneyException.class,
-//			() -> journeyService.myList("test", pageable));
-//
-//		//then
-//		assertEquals(JourneyErrorCode.NOT_FOUND_MEMBER,
-//			exception.getErrorCode());
-//
-//	}
-//
-//
-//}
+package onde.there.journey.service;
+
+import static onde.there.journey.exception.JourneyErrorCode.THERE_IS_NO_MATCHING_THEME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.persistence.EntityManager;
+import onde.there.domain.Journey;
+import onde.there.domain.JourneyTheme;
+import onde.there.domain.Member;
+import onde.there.domain.type.JourneyThemeType;
+import onde.there.domain.type.RegionType;
+import onde.there.dto.journy.JourneyDto;
+import onde.there.dto.journy.JourneyDto.CreateRequest;
+import onde.there.dto.journy.JourneyDto.CreateResponse;
+import onde.there.dto.journy.JourneyDto.JourneyListResponse;
+import onde.there.image.service.AwsS3Service;
+import onde.there.journey.exception.JourneyErrorCode;
+import onde.there.journey.exception.JourneyException;
+import onde.there.journey.repository.JourneyRepository;
+import onde.there.journey.repository.JourneyRepositoryCustom;
+import onde.there.journey.repository.JourneyThemeRepository;
+import onde.there.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class JourneyServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private JourneyRepository journeyRepository;
+
+	@Mock
+	private JourneyThemeRepository journeyThemeRepository;
+
+	@Mock
+	private JourneyRepositoryCustom journeyRepositoryCustom;
+
+	@Mock
+	private AwsS3Service awsS3Service;
+
+	@Mock
+	private EntityManager entityManager;
+
+	@InjectMocks
+	private JourneyService journeyService;
+
+	@Test
+	void createJourneySuccess() throws IOException {
+
+		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+			"온데", "testNickname");
+
+		given(memberRepository.findById(anyString()))
+			.willReturn(Optional.of(member));
+
+		String fileName = "1";
+		String contentType = "png";
+		String filePath = "src/main/resources/testImages/1.png";
+		FileInputStream fileInputStream = new FileInputStream(
+			new File(filePath));
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
+			fileName + "." + contentType, contentType, fileInputStream);
+
+		given(awsS3Service.uploadFiles(any()))
+			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
+
+		ArgumentCaptor<Journey> journeyCaptor = ArgumentCaptor.forClass(
+			Journey.class);
+		ArgumentCaptor<JourneyTheme> journeyThemeCaptor = ArgumentCaptor.forClass(
+			JourneyTheme.class);
+
+		CreateResponse journeyDto = journeyService.createJourney(
+			CreateRequest.builder()
+				.memberId("tHereId")
+				.title("TitleTest")
+				.startDate(LocalDate.parse("2022-10-16"))
+				.endDate(LocalDate.parse("2022-10-17"))
+				.disclosure("public")
+				.journeyThemes(Arrays.asList("힐링", "식도락"))
+				.introductionText("테스트 소개 글")
+				.numberOfPeople(7)
+				.region("서울")
+				.build(),
+			mockMultipartFile,
+			"tHereId"
+		);
+
+		verify(journeyRepository, times(1))
+			.save(journeyCaptor.capture());
+		verify(journeyThemeRepository, times(2))
+			.save(journeyThemeCaptor.capture());
+
+		assertEquals("testNickname", journeyDto.getNickName());
+		assertEquals("TitleTest", journeyDto.getTitle());
+		assertEquals(LocalDate.parse("2022-10-16"),
+			journeyDto.getStartDate());
+		assertEquals(LocalDate.parse("2022-10-17"),
+			journeyDto.getEndDate());
+		assertNotNull(journeyDto.getJourneyThumbnailUrl());
+		assertEquals(JourneyThemeType.HEALING,
+			journeyThemeCaptor.getAllValues().get(0).getJourneyThemeName());
+		assertEquals(JourneyThemeType.RESTAURANT,
+			journeyThemeCaptor.getAllValues().get(1).getJourneyThemeName());
+		assertEquals("서울", journeyDto.getRegion());
+
+	}
+
+	@Test
+	@DisplayName("종료 날짜가 시작 날짜보다 과거 - 여정 생성 실패")
+	void createJourney_DateError() throws IOException {
+
+		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+			"온데", "testNickname");
+
+		given(memberRepository.findById(anyString()))
+			.willReturn(Optional.of(member));
+
+		FileInputStream fis = new FileInputStream(
+			"src/main/resources/testImages/" + "1.png");
+		MockMultipartFile testThumbnail = new MockMultipartFile("1", "1.png",
+			"png", fis);
+
+		JourneyException exception = assertThrows(JourneyException.class,
+			() -> journeyService.createJourney(
+				CreateRequest.builder()
+					.memberId("tHereEmail")
+					.title("TitleTest")
+					.startDate(LocalDate.parse("2022-10-16"))
+					.endDate(LocalDate.parse("2022-10-15"))
+					.disclosure("public")
+					.journeyThemes(Arrays.asList("힐링", "식도락"))
+					.introductionText("테스트 소개 글")
+					.numberOfPeople(7)
+					.region("서울")
+					.build(),
+				testThumbnail,
+				"tHereId"
+			));
+
+		assertEquals(JourneyErrorCode.DATE_ERROR, exception.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("일치하는 테마가 없을 때 - 여정 생성 실패")
+	void createJourney_THERE_IS_NO_MATCHING_THEME() throws IOException {
+
+		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+			"온데", "testNickname");
+
+		given(memberRepository.findById(anyString()))
+			.willReturn(Optional.of(member));
+
+		String fileName = "1";
+		String contentType = "png";
+		String filePath = "src/main/resources/testImages/1.png";
+		FileInputStream fileInputStream = new FileInputStream(
+			new File(filePath));
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
+			fileName + "." + contentType, contentType, fileInputStream);
+
+		given(awsS3Service.uploadFiles(any()))
+			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
+
+		JourneyException exception = assertThrows(JourneyException.class,
+			() -> journeyService.createJourney(
+				JourneyDto.CreateRequest.builder()
+					.memberId("tHereEmail")
+					.title("TitleTest")
+					.startDate(LocalDate.parse("2022-10-16"))
+					.endDate(LocalDate.parse("2022-10-17"))
+					.disclosure("public")
+					.journeyThemes(Arrays.asList("testTheme1", "testTheme2"))
+					.introductionText("테스트 소개 글")
+					.numberOfPeople(7)
+					.region("서울")
+					.build(),
+				mockMultipartFile,
+				"tHereId"
+			));
+
+		assertEquals(THERE_IS_NO_MATCHING_THEME, exception.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("일치하는 region 없을 때 - 여정 생성 실패")
+	void createJourney_NO_AREA_MATCHES() throws IOException {
+
+		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+			"온데", "testNickname");
+
+		given(memberRepository.findById(anyString()))
+			.willReturn(Optional.of(member));
+
+		String fileName = "1";
+		String contentType = "png";
+		String filePath = "src/main/resources/testImages/1.png";
+		FileInputStream fileInputStream = new FileInputStream(
+			new File(filePath));
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName,
+			fileName + "." + contentType, contentType, fileInputStream);
+
+		given(awsS3Service.uploadFiles(any()))
+			.willReturn(new ArrayList<>(Arrays.asList("testUrl")));
+
+		JourneyException exception = assertThrows(JourneyException.class,
+			() -> journeyService.createJourney(
+				JourneyDto.CreateRequest.builder()
+					.memberId("tHereId")
+					.title("TitleTest")
+					.startDate(LocalDate.parse("2022-10-16"))
+					.endDate(LocalDate.parse("2022-10-17"))
+					.disclosure("public")
+					.journeyThemes(Arrays.asList("힐링", "식도락"))
+					.introductionText("테스트 소개 글")
+					.numberOfPeople(7)
+					.region("없는지역")
+					.build(),
+				mockMultipartFile,
+				"tHereId"
+			));
+
+		assertEquals(JourneyErrorCode.NO_REGION_MATCHES,
+			exception.getErrorCode());
+	}
+
+	@Test
+	void JourneyListSuccess() {
+		//given
+		Member member = new Member("tHereId", "tHereEmail", "tHerePassword",
+			"온데", "testNickname");
+
+		List<Journey> journeyList = Arrays.asList(
+			Journey.builder()
+				.id(1L)
+				.member(member)
+				.title("TitleTest")
+				.startDate(LocalDate.parse("2022-10-16"))
+				.endDate(LocalDate.parse("2022-10-17"))
+				.disclosure("public")
+				.introductionText("테스트 소개 글")
+				.numberOfPeople(7)
+				.region(RegionType.SEOUL)
+				.build(),
+			Journey.builder()
+				.id(2L)
+				.member(member)
+				.title("TitleTest2")
+				.startDate(LocalDate.parse("2022-10-16"))
+				.endDate(LocalDate.parse("2022-10-17"))
+				.disclosure("public")
+				.introductionText("테스트 소개 글")
+				.numberOfPeople(7)
+				.region(RegionType.GYEONGGI)
+				.build()
+		);
+
+		List<JourneyTheme> journeyTheme = Arrays.asList(
+			JourneyTheme.builder()
+				.id(1L)
+				.journey(journeyList.get(0))
+				.journeyThemeName(JourneyThemeType.HEALING)
+				.build(),
+			JourneyTheme.builder()
+				.id(1L)
+				.journey(journeyList.get(0))
+				.journeyThemeName(JourneyThemeType.RESTAURANT)
+				.build()
+		);
+
+		given(journeyRepository.findAllByDisclosure(anyString()))
+			.willReturn(journeyList);
+		given(journeyThemeRepository.findAllByJourneyId(any()))
+			.willReturn(journeyTheme);
+
+		//when
+		List<JourneyListResponse> list = journeyService.list();
+
+		//then
+		assertEquals(2, list.size());
+		assertEquals(1L, list.get(0).getJourneyId());
+		assertEquals(2L, list.get(1).getJourneyId());
+		assertEquals("TitleTest", list.get(0).getTitle());
+		assertEquals("TitleTest2", list.get(1).getTitle());
+		assertEquals(Arrays.asList("힐링", "식도락"),
+			list.get(0).getJourneyThemes());
+		assertEquals(Arrays.asList("힐링", "식도락"),
+			list.get(1).getJourneyThemes());
+	}
+
+	@Test
+	@DisplayName("존재하는 유저가 아닐 때 - 내 여정 조회 실패")
+	void MyJourneyList_NOT_FOUND_MEMBER() {
+		//given
+		given(memberRepository.findById(anyString()))
+			.willReturn(Optional.empty());
+
+		Pageable pageable = Pageable.ofSize(15);
+
+		//when
+		JourneyException exception = assertThrows(JourneyException.class,
+			() -> journeyService.myList("test", pageable));
+
+		//then
+		assertEquals(JourneyErrorCode.NOT_FOUND_MEMBER,
+			exception.getErrorCode());
+
+	}
+
+
+}

--- a/server/src/test/java/onde/there/journey/service/JourneyServiceTest2.java
+++ b/server/src/test/java/onde/there/journey/service/JourneyServiceTest2.java
@@ -232,8 +232,10 @@ public class JourneyServiceTest2 {
 			"TitleTest");
 		assertThat(result.getContent().get(1).getTitle()).isEqualTo(
 			"TitleTest2");
-		assertThat(result.getContent().get(0).getRegion()).isEqualTo(RegionType.SEOUL);
-		assertThat(result.getContent().get(1).getRegion()).isEqualTo(RegionType.GYEONGGI);
+		assertThat(result.getContent().get(0).getRegion()).isEqualTo(
+			RegionType.SEOUL);
+		assertThat(result.getContent().get(1).getRegion()).isEqualTo(
+			RegionType.GYEONGGI);
 
 
 	}


### PR DESCRIPTION
## 📖 설명 📖

- 페이징 처리에서, Pageable 잘못된 값이 return -> 올바른 Pageable 값으로 return
```java
PageImpl<MyListResponse> MyListResponses = new PageImpl<>(
			journeyRepository.myList(memberId, pageable).stream()
				.map(MyListResponse::fromEntity).collect(
					Collectors.toList()));
```
 `new PageImpl` 부분에서 pageble이 들어가지 않아서 default 값으로 객체 생성 되었기 때문에 올바른 pageable 값이 반환이 안됐습니다.
`Page<Journey> journeys = journeyRepository.searchAll(filteringRequest, pageable);`을 querydsl로 받은 다음 

`return journeys.map(FilteringResponse::fromEntity);`을 통해 dto로 형변환을 해줘서 반환하게 수정
애초에  `new PageImpl`할 필요가 없었습니다.

- querydsl 쿼리문 최적화 
count 쿼리와, journey를 검색하는 결과 값이 불일치 했었습니다.
`.select(journey.count())` -> `.select(journey.countDistinct())` 로 수정하여 중복된 journey에 대해서 count하지 않게 수정하였습니다.
그리고, Member에 대해서 query문이 따로 날아갔었는데
```java
.innerJoin(journey.member, member)
.fetchJoin()
```
를 통해서 하나의 쿼리문으로 통합하였습니다.


<br>

## 🔧 추가 및 수정 🔧️

-

<br>

## ✨ 이건 꼭 봐주세요! ✨

- member Entity에 profileImageUrl이 추가되면 반환하게 수정할 예정입니다
- 특정 member nickName을 통해 public한 journey목록을 반환할 수 있는 service를 구현할 예정입니다.