### PR TITLE
Fix : JourneyService 수정

### DIFF
--- a/server/src/main/java/onde/there/journey/controller/JourneyController.java
+++ b/server/src/main/java/onde/there/journey/controller/JourneyController.java
@@ -65,7 +65,7 @@ public class JourneyController {
 		@Parameter(name = "여정 정보", description = "수정할 여정에 대한 정보", required = true,
 			content = @Content(schema = @Schema(implementation = JourneyDto.UpdateRequest.class)))
 		@RequestPart @Valid JourneyDto.UpdateRequest request,
-		@Parameter(description = "Thumbnail 이미지 파일", required = true)
+		@Parameter(description = "Thumbnail 이미지 파일", required = false)
 		@RequestPart MultipartFile thumbnail,
 		@TokenMemberId String memberId) {
 

--- a/server/src/main/java/onde/there/journey/service/JourneyService.java
+++ b/server/src/main/java/onde/there/journey/service/JourneyService.java
@@ -329,13 +329,9 @@ public class JourneyService {
 		}
 		log.info("updateJourney() : journeyTheme 수정 완료");
 
-		if (!thumbnail.isEmpty()) {
-			awsS3Service.deleteFile(journey.getJourneyThumbnailUrl());
-			List<String> imageUrls = awsS3Service.uploadFiles(
-				Collections.singletonList(thumbnail));
-			journey.setJourneyThumbnailUrl(imageUrls.get(0));
-		}
 
+		String imageUrl = updateThumbnailUrl(thumbnail, journey);
+		journey.setJourneyThumbnailUrl(imageUrl);
 		journey.setTitle(request.getTitle());
 		journey.setStartDate(request.getStartDate());
 		journey.setEndDate(request.getEndDate());
@@ -369,5 +365,10 @@ public class JourneyService {
 		if (memberId == null) {
 			throw new JourneyException(AVAILABLE_AFTER_LONGIN);
 		}
+	}
+
+	private String updateThumbnailUrl(MultipartFile multipartFile, Journey journey) {
+		boolean condition = multipartFile == null || multipartFile.isEmpty();
+		return condition ? journey.getJourneyThumbnailUrl() : awsS3Service.uploadFiles(List.of(multipartFile)).get(0);
 	}
 }


### PR DESCRIPTION
여정 수정시 multipartFile null 처리 해결

## 📖 설명 📖

- controller에 `required = false`
- multipartFile 상태 확인
```java
private String updateThumbnailUrl(MultipartFile multipartFile, Journey journey) {
		boolean condition = multipartFile == null || multipartFile.isEmpty();
		return condition ? journey.getJourneyThumbnailUrl() : awsS3Service.uploadFiles(List.of(multipartFile)).get(0);
	}
```

<br>

## 🔧 추가 및 수정 🔧️

-

<br>

## ✨ 이건 꼭 봐주세요! ✨

-